### PR TITLE
Security: Move subscription ID to GitHub secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ env:
   AZURE_FUNCTIONAPP_NAME: lqdevwebmentions-flex
   AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'
   DOTNET_VERSION: '10.0.x'
-  AZURE_SUBSCRIPTION_ID: '0ecbb599-849f-4d64-a97d-808abd3b8572'
 
 jobs:
   build-and-deploy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,6 @@ Configured in [Program.fs](Program.fs) during dependency injection setup.
 Current deployment target:
 - **Function App**: `lqdevwebmentions-flex`
 - **Resource Group**: `luisquintanillamewm-rg`
-- **Subscription**: `0ecbb599-849f-4d64-a97d-808abd3b8572`
 - **Plan Type**: Flex Consumption
 - **Runtime Stack**: `dotnet-isolated` version `10.0`
 - **Location**: East US 2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An Azure Functions-based service for receiving, validating, and processing [Webmentions](https://www.w3.org/TR/webmention/) written in F#. This service accepts webmention notifications, validates them, stores them in Azure Table Storage, and generates RSS feeds from the collected mentions.
 
+**Live Service**: `https://webmentions.lqdev.tech/api/inbox`
+
 ## What are Webmentions?
 
 Webmentions are a web standard for notifications between websites. When someone mentions your website on their blog, social media, or any other web platform, a webmention allows your site to be automatically notified about the mention. This enables decentralized social interactions across the web.
@@ -37,7 +39,7 @@ The service consists of two main Azure Functions:
 
 ## Prerequisites
 
-- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - Azure Storage Account (for Table Storage and Blob Storage)
 

--- a/docs/projects/active/flex-consumption-migration.md
+++ b/docs/projects/active/flex-consumption-migration.md
@@ -88,41 +88,91 @@ Function app may have malformed content.
 
 ## Acceptance Criteria
 
-- [ ] New Flex Consumption app `lqdevwebmentions-flex` operational
-- [ ] .NET 10 isolated worker runtime confirmed
-- [ ] HTTP POST to `/api/inbox` stores webmentions successfully
+- [x] New Flex Consumption app `lqdevwebmentions-flex` operational
+- [x] .NET 10 isolated worker runtime confirmed
+- [x] Custom domain `webmentions.lqdev.tech` configured with free SSL
+- [ ] HTTP POST to `/api/inbox` stores webmentions successfully (pending test)
 - [ ] Timer trigger executes daily at 3 AM UTC
 - [ ] RSS feed generated in Blob Storage `feeds/webmentions/index.xml`
 - [ ] Table Storage reads/writes functioning
-- [ ] GitHub Actions deployment pipeline updated and working
-- [ ] Zero cost confirmed (within 250K execution free tier)
-- [ ] Application Insights logging operational
-- [ ] All documentation updated with new app name
-- [ ] No production downtime during migration
+- [x] GitHub Actions deployment pipeline updated and working
+- [x] Zero cost confirmed (within 250K execution free tier)
+- [x] Application Insights logging operational
+- [x] All documentation updated with new app name
+- [x] No production downtime during migration
 
 ## Technical Notes
 
 ### Azure CLI Migration Commands
 
 ```bash
-# 1. Check eligibility
-az functionapp flex-migration list
-
-# 2. Start automated migration
-az functionapp flex-migration start \
-  --name lqdevwebmentions \
+# Created new Flex app directly instead of migration tool
+az functionapp create \
+  --name lqdevwebmentions-flex \
   --resource-group luisquintanillamewm-rg \
-  --new-plan-name lqdevwebmentions-flex-plan \
-  --new-app-name lqdevwebmentions-flex
+  --storage-account luisquintanillamewmae45 \
+  --functions-version 4 \
+  --runtime dotnet-isolated \
+  --runtime-version 10 \
+  --os-type Linux \
+  --flexconsumption-location eastus2
 
-# 3. Verify new app
+# Configure app settings
+az functionapp config appsettings set \
+  --name lqdevwebmentions-flex \
+  --resource-group luisquintanillamewm-rg \
+  --settings PERSONAL_WEBSITE_HOSTNAMES="lqdev.me,www.lqdev.me,luisquintanilla.me,www.luisquintanilla.me"
+
+# Verify new app
+az functionapp show \
+  --name lqdevwebmentions-flex \
+```
+
+### Custom Domain Configuration
+
+**Domain**: `webmentions.lqdev.tech`
+
+**Steps completed**:
+1. Updated DNS CNAME record at Namecheap:
+   - `webmentions.lqdev.tech` → `lqdevwebmentions-flex.azurewebsites.net`
+2. Added custom domain to Function App:
+   ```bash
+   az functionapp config hostname add \
+     --resource-group luisquintanillamewm-rg \
+     --name lqdevwebmentions-flex \
+     --hostname webmentions.lqdev.tech
+   ```
+3. Created free managed SSL certificate:
+   ```bash
+   az functionapp config ssl create \
+     --resource-group luisquintanillamewm-rg \
+     --name lqdevwebmentions-flex \
+     --hostname webmentions.lqdev.tech
+   ```
+4. Bound SSL certificate for HTTPS:
+   ```bash
+   az functionapp config ssl bind \
+     --resource-group luisquintanillamewm-rg \
+     --name lqdevwebmentions-flex \
+     --certificate-thumbprint C751FFD99171DA4C38E043420A1C92FC6B97EDDF \
+     --ssl-type SNI
+   ```
+
+**Result**: `https://webmentions.lqdev.tech/api/inbox` now works with free SSL
+
+**Cost**: $0 (App Service Managed Certificate is free, no Azure Front Door needed)
+
+### Verification Commands
+
+```bash
+# Check app configuration
 az functionapp show \
   --name lqdevwebmentions-flex \
   --resource-group luisquintanillamewm-rg \
   --query "{name:name, kind:kind, sku:properties.sku, state:state}" \
   --output table
 
-# 4. Check app settings
+# Check app settings
 az functionapp config appsettings list \
   --name lqdevwebmentions-flex \
   --resource-group luisquintanillamewm-rg \


### PR DESCRIPTION
Removes hardcoded subscription ID from workflow and documentation.

## Changes
- Moved AZURE_SUBSCRIPTION_ID to GitHub secret
- Removed subscription ID from workflow env vars
- Removed subscription ID from AGENTS.md
- Updated custom domain and SSL documentation

## Security
- Subscription ID now stored securely in GitHub Secrets
- Going forward, no sensitive IDs in tracked files